### PR TITLE
Add link on vts json documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ docker run  -ti --rm --env NGIX_HOST="http://localhost/status/format/json" --env
 
 ## Metrics
 
-Documents about exposed Prometheus metrics
+Documents about exposed Prometheus metrics. For details on the underlying metrics please see [nginx-module-vts](https://github.com/vozlt/nginx-module-vts#json-used-by-status)
 
 ### Server main
 


### PR DESCRIPTION
Hi,

I came here to understand more about how the underlying metrics are calculated and it took me quite a while to understand that this is actually completely controlled by the nginx vts module. I therefore think this link might make it a little more clear.

Regards,

Tobi